### PR TITLE
update async_timeout version to match upstream

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from setuptools import setup, find_packages
 
-install_requires = ["psycopg2-binary>=2.8.4", "async_timeout>=3.0,<4.0"]
+install_requires = ["psycopg2-binary>=2.8.4", "async_timeout>=3.0,<5.0"]
 extras_require = {"sa": ["sqlalchemy[postgresql_psycopg2binary]>=1.3,<1.5"]}
 
 


### PR DESCRIPTION
this was causing sub-dependency version mismatch errors when updating to python 3.10